### PR TITLE
Wrapped the curl package definition with a defined check

### DIFF
--- a/manifests/curl.pp
+++ b/manifests/curl.pp
@@ -3,6 +3,8 @@
 # This clas installs cURL and ensures it is installed before
 # any S3file resources are evaluated.
 class s3file::curl () {
-  package { 'curl':
-  } -> S3file<| |>
+  if !defined(Package['curl']) {
+    package { 'curl':
+    } -> S3file<| |>
+  }
 }


### PR DESCRIPTION
I like how your module works.  The only trouble that I have had is that I have other modules that create a define for curl as well.  If they were executed before the include 's3file::curl' then you get a duplicate resource error.  I have simply wrapped the define with a defined check so that it doesn't matter if another module defines it first.
