### PR TITLE
Rename s3file class to s3::file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Example Usage:
 
-    include 's3file::curl'
-    s3file { '/path/to/destination/file':
+    include 's3::curl'
+    s3::file { '/path/to/destination/file':
       source => 'MyBucket/the/file',
       ensure => 'latest',
     }

--- a/manifests/curl.pp
+++ b/manifests/curl.pp
@@ -1,8 +1,8 @@
-# Class: s3file::curl
+# Class: s3::curl
 #
 # This clas installs cURL and ensures it is installed before
-# any S3file resources are evaluated.
-class s3file::curl () {
+# any S3::File resources are evaluated.
+class s3::curl () {
   package { 'curl':
-  } -> S3file<| |>
+  } -> S3::File<| |>
 }

--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -1,4 +1,4 @@
-# Definition: s3file
+# Definition: s3::file
 #
 # This definition fetches and keeps synchonized a file stored in S3
 #
@@ -13,12 +13,12 @@
 #
 # Sample Usage:
 #
-#  s3file { '/opt/minecraft/minecraft_server.jar':
+#  s3::file { '/opt/minecraft/minecraft_server.jar':
 #    source => 'MinecraftDownload/launcher/minecraft_server.jar',
 #    ensure => 'latest',
 #  }
 #
-define s3file (
+define s3::file (
   $source,
   $ensure = 'latest',
   $s3_domain = 's3.amazonaws.com',


### PR DESCRIPTION
I could not get 's3file' to work on Puppet 2.7.11.  Comparing this definition to similar objects I used elsewhere, I found that qualifying the name of the module and the name of the defined object worked well.  I renamed the module  from s3file to s3, and renamed init.pp to file.pp, so the define formerly known as s3file is now known as s3::file.

My assumption here is that the 's3file' construct no longer works in Puppet 2.7.x, and that you must have created this definition on an earlier version of Puppet, where placing a define in an init.pp file was okay.  I don't have a ton of experience with Puppet, though, so feel free to tell me I'm off base here.  The main reason I am submitting this as a PR is that my PR on your minecraft module depends on this change.
