### PR TITLE
Adding the option to access files in buckets in VPCs with S3 VPC Endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Example Usage:
 
     include 's3file::curl'
     s3file { '/path/to/destination/file':
-      source => 'MyBucket/the/file',
-      ensure => 'latest',
+      source       => 'MyBucket/the/file',
+      ensure       => 'latest',
+      vpc_endpoint => 'true', # Default is false
     }
+    

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,7 +28,6 @@ define s3file (
 {
   $valid_ensures = [ 'absent', 'present', 'latest' ]
   validate_re($ensure, $valid_ensures)
-
   if $ensure == 'absent' {
     # We use a puppet resource here to force the file to absent state
     file { $name:
@@ -36,20 +35,19 @@ define s3file (
     }
   } else {
     if $vpc_endpoint == true {
-      $bucket_file = split($source, '/')
-      $bucket = $bucket_file[0]
-      $file = $bucket_file[1]
-      $real_source = "https://${bucket}.${s3_domain}/${file}"
+      $bucket_file_array = split($source, '/')
+      $bucket_array = [$bucket_file_array[0],]
+      $file_array = difference($bucket_file_array,$bucket_array)
+      $file = join($file_array, "/")
+      $real_source = "https://${bucket_array[0]}.${s3_domain}/${file}"
     } else {
       $real_source = "https://${s3_domain}/${source}"
     }
-
     if $ensure == 'latest' {
       $unless = "[ -e ${name} ] && curl -I ${real_source} | grep ETag | grep `md5sum ${name} | cut -c1-32`"
     } else {
       $unless = "[ -e ${name} ]"
     }
-
     exec { "fetch ${name}":
       path    => ['/bin', '/usr/bin', 'sbin', '/usr/sbin'],
       command => "curl -L -o ${name} ${real_source}",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,8 +36,9 @@ define s3file (
     }
   } else {
     if $vpc_endpoint == true {
-      $bucket=$source.split('/', 2).values.first
-      $file=$source.split('/', 2).values.second
+      $bucket_file = split($source, '/')
+      $bucket = $bucket_file[0]
+      $file = $bucket_file[1]
       $real_source = "https://${bucket}.${s3_domain}/${file}"
     } else {
       $real_source = "https://${s3_domain}/${source}"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,6 +23,7 @@ define s3file (
   $source,
   $ensure = 'latest',
   $s3_domain = 's3.amazonaws.com',
+  $vpc_endpoint = 'false',
 )
 {
   $valid_ensures = [ 'absent', 'present', 'latest' ]

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,6 +7,7 @@
 # - $source: The bucket and filename on S3
 # - $ensure: 'present', 'absent', or 'latest': as the core File resource
 # - $s3_domain: s3 server to fetch the file from
+# - vpc_endpoint: 'true' or 'false'
 #
 # Requires:
 # - cURL
@@ -33,7 +34,13 @@ define s3file (
       ensure => absent
     }
   } else {
-    $real_source = "https://${s3_domain}/${source}"
+    if $vpc_endpoint == 'true' {
+      $bucket=$source.split('/', 2).values.first
+      $file=$source.split('/', 2).values.second
+      $real_source = "https://${bucket}.${s3_domain}/${file}"
+    } else {
+      $real_source = "https://${s3_domain}/${source}"
+    }
 
     if $ensure == 'latest' {
       $unless = "[ -e ${name} ] && curl -I ${real_source} | grep ETag | grep `md5sum ${name} | cut -c1-32`"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,7 +7,7 @@
 # - $source: The bucket and filename on S3
 # - $ensure: 'present', 'absent', or 'latest': as the core File resource
 # - $s3_domain: s3 server to fetch the file from
-# - $vpc_endpoint: 'true' or 'false'
+# - $vpc_endpoint: true or false
 #
 # Requires:
 # - cURL

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,7 +7,7 @@
 # - $source: The bucket and filename on S3
 # - $ensure: 'present', 'absent', or 'latest': as the core File resource
 # - $s3_domain: s3 server to fetch the file from
-# - vpc_endpoint: 'true' or 'false'
+# - $vpc_endpoint: 'true' or 'false'
 #
 # Requires:
 # - cURL
@@ -23,7 +23,7 @@ define s3file (
   $source,
   $ensure = 'latest',
   $s3_domain = 's3.amazonaws.com',
-  $vpc_endpoint = 'false',
+  $vpc_endpoint = false,
 )
 {
   $valid_ensures = [ 'absent', 'present', 'latest' ]
@@ -35,7 +35,7 @@ define s3file (
       ensure => absent
     }
   } else {
-    if $vpc_endpoint == 'true' {
+    if $vpc_endpoint == true {
       $bucket=$source.split('/', 2).values.first
       $file=$source.split('/', 2).values.second
       $real_source = "https://${bucket}.${s3_domain}/${file}"


### PR DESCRIPTION
VPC endpoints necessitate the use of a different URL for retrieving files. This change reformats the bucket/file input to cater for this whilst preserving original functionality by default.